### PR TITLE
Add plist file for brew services

### DIFF
--- a/coda.rb
+++ b/coda.rb
@@ -1,4 +1,5 @@
 class Coda < Formula
+  # Note: Do not forget to update the peers below!
   desc "Coda is the first cryptocurrency protocol with a succinct blockchain."
   homepage "https://github.com/CodaProtocol/coda"
   url "https://s3-us-west-2.amazonaws.com/packages.o1test.net/0.0.13-beta/homebrew-coda.tar.gz"
@@ -16,6 +17,42 @@ class Coda < Formula
   conflicts_with "coda-dev"
 
   bottle :unneeded
+  
+    plist_options :manual => "coda"
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{bin}/coda</string>
+        <string>daemon</string>
+        <string>-peer</string>
+        <string>/dns4/seed-one.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWP7fTKbyiUcYJGajQDpCFo2rDexgTHFJTxCH8jvcL1eAH</string>
+        <string>-peer</string>
+        <string>/dns4/seed-two.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWL9ywbiXNfMBqnUKHSB1Q1BaHFNUzppu6JLMVn9TTPFSA</string>
+      </array>
+      <key>KeepAlive</key>
+      <true/>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>EnvironmentVariables</key>
+      <dict>
+        <key>PATH</key>
+        <string>#{bin}:/usr/bin</string>
+      </dict>
+      <key>StandardErrorPath</key>
+      <string>/tmp/coda.service.err</string>
+      <key>StandardOutPath</key>
+      <string>/tmp/coda.service.out</string>
+    </dict>
+    </plist>
+  EOS
+  end
 
   def install
     bin.install("coda")

--- a/coda.rb
+++ b/coda.rb
@@ -1,10 +1,11 @@
 class Coda < Formula
-  # Note: Do not forget to update the peers below!
   desc "Coda is the first cryptocurrency protocol with a succinct blockchain."
   homepage "https://github.com/CodaProtocol/coda"
   url "https://s3-us-west-2.amazonaws.com/packages.o1test.net/0.0.13-beta/homebrew-coda.tar.gz"
   sha256 "a9b826e392efdec515debcdae72f6fd760938231b58495fb8b8d7950104e7ef9"
   revision 26
+  @peer1 = "/dns4/seed-one.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWP7fTKbyiUcYJGajQDpCFo2rDexgTHFJTxCH8jvcL1eAH"
+  @peer2 = "/dns4/seed-two.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWL9ywbiXNfMBqnUKHSB1Q1BaHFNUzppu6JLMVn9TTPFSA"
 
   depends_on "gmp"
   depends_on "jemalloc"
@@ -32,9 +33,9 @@ class Coda < Formula
         <string>#{bin}/coda</string>
         <string>daemon</string>
         <string>-peer</string>
-        <string>/dns4/seed-one.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWP7fTKbyiUcYJGajQDpCFo2rDexgTHFJTxCH8jvcL1eAH</string>
+        <string>#{@peer1}</string>
         <string>-peer</string>
-        <string>/dns4/seed-two.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWL9ywbiXNfMBqnUKHSB1Q1BaHFNUzppu6JLMVn9TTPFSA</string>
+        <string>#{@peer2}</string>
       </array>
       <key>KeepAlive</key>
       <true/>


### PR DESCRIPTION
This allows you to run `brew services start coda`, which runs coda in the background and restarts it if it crashes.

The default peers are hardcoded into the plist. We already need to update this file every time we releas so it didn't seem like a dealbreaker, hopefully we eventually have the daemon able to auto-discover these.
This may be enough configuration for now, since you can access the GraphQL port to change staker settings etc (https://github.com/CodaProtocol/coda/pull/4467 tries to improve the UX there). If there's something I'm missing lmk.

```
avery@mbp $ brew install codaprotocol/coda/coda
==> Downloading https://s3-us-west-2.amazonaws.com/packages.o1test.net/0.0.13-beta/homebrew-coda.tar.gz
Already downloaded: /Users/avery/Library/Caches/Homebrew/downloads/c47f9b3f9fdb74173a4c8d7971928127b0c4232788a365e9008b0ce55bcddf84--homebrew-coda.tar.gz
==> Caveats
To have launchd start coda now and restart at login:
  brew services start coda
Or, if you don't want/need a background service you can just run:
  coda
avery@mbp $ brew services list
Name     Status  User  Plist
coda     started avery /Users/avery/Library/LaunchAgents/homebrew.mxcl.codatest.plist
```