### PR TITLE
Update coda-generate-keypair-phase3 for Phase 3.3

### DIFF
--- a/coda-generate-keypair-phase3.rb
+++ b/coda-generate-keypair-phase3.rb
@@ -1,9 +1,9 @@
 class CodaGenerateKeypairPhase3 < Formula
   desc "Coda is the first cryptocurrency protocol with a succinct blockchain."
   homepage "https://github.com/CodaProtocol/coda"
-  url "https://storage.googleapis.com/network-debug/coda-generate-keypair-phase3/homebrew-coda-generate-keypair-phase3.tar.gz"
-  sha256 "3a19f5168f58501ec6de4c8f72fe49bd6f651537e37f4a8760e9d4bc8676d87a"
-  revision 101
+  url "https://storage.googleapis.com/network-debug/coda-generate-keypair-phase3/homebrew-coda-generate-keypair-phase3-3.tar.gz"
+  sha256 "13cd7636ee91dc9a22e001a8bbd8759a03adb8806c6ac59c5365a4f1d9d9a585"
+  revision 102
   depends_on "openssl"
   depends_on "libsodium"
   depends_on "gmp"


### PR DESCRIPTION
We've updated the keypair format so this new brew package generates keys compatible with the new format.